### PR TITLE
Improve login layout and add dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# News
+# Next_n_Now Login
+
+This project contains a simple login page. To view it locally using a Node.js server:
+
+```bash
+npm install     # install dependencies the first time
+npm start       # start the development server
+```
+
+Then open [http://localhost:3000/login.html](http://localhost:3000/login.html) in your browser.

--- a/login.html
+++ b/login.html
@@ -10,6 +10,9 @@
     <header>
         <div class="company-name">Next_n_Now</div>
     </header>
+    <div class="news-ticker">
+        <div class="ticker-text">Breaking News - Stay updated with Next_n_Now &bull; Breaking News - Stay updated with Next_n_Now</div>
+    </div>
     <main>
         <form id="loginForm" novalidate>
             <div class="form-group">
@@ -25,10 +28,10 @@
                 <label for="terms">I agree to the <a href="terms.html" target="_blank">Terms and Conditions</a></label>
             </div>
             <button type="submit" id="loginBtn" disabled>Login</button>
+            <div class="signup-link">
+                <a href="signup.html">Sign up</a>
+            </div>
         </form>
-        <div class="signup-link">
-            <a href="signup.html">Sign up</a>
-        </div>
     </main>
     <script src="script.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "next_n_now",
+  "version": "1.0.0",
+  "description": "Simple server for Next_n_Now login page",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(__dirname));
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/style.css
+++ b/style.css
@@ -12,9 +12,32 @@ body {
     flex-direction: column;
 }
 
+.news-ticker {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    overflow: hidden;
+    background: #222;
+    color: #fff;
+    pointer-events: none;
+}
+
+.news-ticker .ticker-text {
+    display: inline-block;
+    padding-left: 100%;
+    white-space: nowrap;
+    animation: ticker 20s linear infinite;
+}
+
+@keyframes ticker {
+    from { transform: translateX(0); }
+    to { transform: translateX(-100%); }
+}
+
 header {
     padding: 1rem;
-    text-align: right;
+    text-align: left;
     background-color: #fff;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
@@ -86,6 +109,13 @@ button[type="submit"]:enabled {
 .signup-link {
     text-align: center;
     margin-top: 1rem;
+}
+
+.signup-link a {
+    display: inline-block;
+    margin-top: 0.5rem;
+    color: #007bff;
+    text-decoration: none;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- adjust header to align site title left
- move signup link inside form and add news ticker animation
- add Node.js/Express server to serve static files
- document how to run the server

## Testing
- `npm install` *(fails: network access blocked)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688335d2ac48832686704f7f6c1d4e1e