### PR TITLE
Serve login page from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ npm install     # install dependencies the first time
 npm start       # start the development server
 ```
 
-Then open [http://localhost:3000/login.html](http://localhost:3000/login.html) in your browser.
+The server will automatically open [http://localhost:3000/login.html](http://localhost:3000/login.html) in your default browser. You can also browse to `http://localhost:3000/`, which now displays the same login page.

--- a/server.js
+++ b/server.js
@@ -1,10 +1,26 @@
 const express = require('express');
 const path = require('path');
+const { exec } = require('child_process');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.static(__dirname));
 
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'login.html'));
+});
+
+function openBrowser(url) {
+  const startCommand = process.platform === 'darwin'
+    ? 'open'
+    : process.platform === 'win32'
+    ? 'start'
+    : 'xdg-open';
+  exec(`${startCommand} ${url}`);
+}
+
 app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
+  const url = `http://localhost:${PORT}/login.html`;
+  console.log(`Server running on ${url}`);
+  openBrowser(url);
 });


### PR DESCRIPTION
## Summary
- expose `login.html` at `/` and open it automatically when the server starts
- document the new behavior in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68833cfed7108326ac1a9a3811b1cf35