### PR TITLE
Add signup and fix login glitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # Next_n_Now Login
 
-This project contains a simple login page. To view it locally using a Node.js server:
+This project now includes a basic registration and login flow using a PostgreSQL database.
+
+## Setup
+
+1. Install dependencies:
 
 ```bash
-npm install     # install dependencies the first time
-npm start       # start the development server
+npm install
 ```
 
-The server will automatically open [http://localhost:3000/login.html](http://localhost:3000/login.html) in your default browser. You can also browse to `http://localhost:3000/`, which now displays the same login page.
+2. Provide a PostgreSQL connection string via the `DATABASE_URL` environment variable.
+
+3. Start the server:
+
+```bash
+npm start
+```
+
+The server opens [http://localhost:3000/login.html](http://localhost:3000/login.html).
+
+Registered users can log in, and new users can register through `signup.html`.

--- a/login.html
+++ b/login.html
@@ -13,9 +13,8 @@
     <div class="news-ticker">
         <div class="ticker-text">Breaking News - Stay updated with Next_n_Now &bull; Breaking News - Stay updated with Next_n_Now</div>
     </div>
- main
     <main>
-        <form id="loginForm" novalidate>
+        <form id="loginForm" novalidate method="POST" action="/login">
             <div class="form-group">
                 <label for="email">Email</label>
                 <input type="email" id="email" name="email" required>
@@ -33,7 +32,6 @@
                 <a href="signup.html">Sign up</a>
             </div>
         </form>
-main
     </main>
     <script src="script.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "pg": "^8.11.0",
+    "bcrypt": "^5.1.0"
   }
 }

--- a/script.js
+++ b/script.js
@@ -20,7 +20,6 @@ document.addEventListener('DOMContentLoaded', function() {
     passwordInput.addEventListener('input', updateButtonState);
     termsCheckbox.addEventListener('change', updateButtonState);
 
-main
     document.getElementById('loginForm').addEventListener('submit', function(e) {
         if (loginBtn.disabled) {
             e.preventDefault();

--- a/server.js
+++ b/server.js
@@ -1,13 +1,63 @@
 const express = require('express');
 const path = require('path');
 const { exec } = require('child_process');
+const { Pool } = require('pg');
+const bcrypt = require('bcrypt');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.static(__dirname));
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+// Configure postgres connection
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function ensureTable() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    username TEXT NOT NULL,
+    password TEXT NOT NULL
+  )`);
+}
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'login.html'));
+});
+
+app.post('/register', async (req, res) => {
+  const { email, username, password } = req.body;
+  if (!email || !username || !password) {
+    return res.status(400).send('Missing fields');
+  }
+  const hash = await bcrypt.hash(password, 10);
+  try {
+    await pool.query('INSERT INTO users(email, username, password) VALUES($1,$2,$3)', [email, username, hash]);
+    res.redirect('/login.html');
+  } catch (err) {
+    res.status(500).send('Error registering user');
+  }
+});
+
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).send('Missing credentials');
+  }
+  try {
+    const result = await pool.query('SELECT password FROM users WHERE email=$1', [email]);
+    if (result.rowCount === 0) return res.status(401).send('Invalid credentials');
+    const match = await bcrypt.compare(password, result.rows[0].password);
+    if (match) {
+      res.send('Logged in');
+    } else {
+      res.status(401).send('Invalid credentials');
+    }
+  } catch (err) {
+    res.status(500).send('Error logging in');
+  }
 });
 
 function openBrowser(url) {
@@ -19,7 +69,8 @@ function openBrowser(url) {
   exec(`${startCommand} ${url}`);
 }
 
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
+  await ensureTable();
   const url = `http://localhost:${PORT}/login.html`;
   console.log(`Server running on ${url}`);
   openBrowser(url);

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up - Next_n_Now</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="company-name">Next_n_Now</div>
+    </header>
+    <div class="news-ticker">
+        <div class="ticker-text">Breaking News - Stay updated with Next_n_Now &bull; Breaking News - Stay updated with Next_n_Now</div>
+    </div>
+    <main>
+        <form id="signupForm" novalidate method="POST" action="/register">
+            <div class="form-group">
+                <label for="signupEmail">Email</label>
+                <input type="email" id="signupEmail" name="email" required>
+            </div>
+            <div class="form-group">
+                <label for="username">User Name</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+                <label for="signupPassword">Password</label>
+                <input type="password" id="signupPassword" name="password" required>
+            </div>
+            <div class="form-group">
+                <label for="confirmPassword">Confirm Password</label>
+                <input type="password" id="confirmPassword" required>
+            </div>
+            <button type="submit" id="signupBtn" disabled>Register</button>
+            <div class="signup-link">
+                <a href="login.html">Back to login</a>
+            </div>
+        </form>
+    </main>
+    <script src="signup.js"></script>
+</body>
+</html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const emailInput = document.getElementById('signupEmail');
+    const usernameInput = document.getElementById('username');
+    const passwordInput = document.getElementById('signupPassword');
+    const confirmInput = document.getElementById('confirmPassword');
+    const signupBtn = document.getElementById('signupBtn');
+
+    function validateEmail(email) {
+        const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return re.test(email);
+    }
+
+    function updateButtonState() {
+        const emailValid = validateEmail(emailInput.value);
+        const usernameValid = usernameInput.value.trim() !== '';
+        const passwordValid = passwordInput.value.length >= 6;
+        const passwordsMatch = passwordInput.value === confirmInput.value;
+        signupBtn.disabled = !(emailValid && usernameValid && passwordValid && passwordsMatch);
+    }
+
+    emailInput.addEventListener('input', updateButtonState);
+    usernameInput.addEventListener('input', updateButtonState);
+    passwordInput.addEventListener('input', updateButtonState);
+    confirmInput.addEventListener('input', updateButtonState);
+
+    document.getElementById('signupForm').addEventListener('submit', function(e) {
+        if (signupBtn.disabled) {
+            e.preventDefault();
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -7,7 +7,6 @@
 body {
     font-family: Arial, sans-serif;
     background: #f4f4f4;
-main
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -38,7 +37,6 @@ main
 header {
     padding: 1rem;
     text-align: left;
-main
     background-color: #fff;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
@@ -89,7 +87,6 @@ form {
 
 .checkbox-group label {
     margin-left: 0.5rem;
-main
 }
 
 button[type="submit"] {
@@ -119,10 +116,8 @@ button[type="submit"]:enabled {
     text-decoration: none;
 }
 
-main
 @media (max-width: 600px) {
     form {
         padding: 1rem;
     }
 }
-main


### PR DESCRIPTION
## Summary
- clean up stray `main` text in login, script, and CSS
- add registration page with validation
- wire Express server to PostgreSQL for user registration and login
- document new setup with database requirement

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688356c817fc8326a50816c6a33f4f26